### PR TITLE
Several improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+archives/

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 archives/
+test.txt
+output.txt
+keywords.txt

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ urlhunter requires 3 parameters to run: `-keywords`, `-date` and `-o`.
 
 For example: `urlhunter -keywords keywords.txt -date 2020-11-20 -o out.txt`
 
-### -keywords
+### --keywords
 
 You need to specify the txt file that contains keywords to search on URLs. Keywords must be written line by line. You have three different ways to specify keywords:
 
@@ -55,7 +55,7 @@ You need to specify the txt file that contains keywords to search on URLs. Keywo
 
 `regex 1\d{10}` will match `https://example.com/index.php?id=12938454312` but **_won't_** match `https://example.com/index.php?id=abc223`
 
-### -date
+### --date
 
 urlhunter downloads the archive files of the given date(s). You have three different ways to specify the date:
 
@@ -69,7 +69,7 @@ For example: `-date 2020-11-20`
 
 For example: `-date 2020-11-10:2020-11-20`
 
-### -o
+### --output
 
 You can specify the output file with `-o` parameter. For example `-o out.txt`
 

--- a/main.go
+++ b/main.go
@@ -42,11 +42,37 @@ type Files struct {
 	} `xml:"file"`
 }
 
+const usage = `Usage: ./urlhunter --keywords /path/to/keywordsFile --date DATE-RANGE-HERE --output /path/to/outputFile
+Example: ./urlhunter --keywords keywords.txt --date 2020-11-20 --output out.txt
+  -k, --keywords /path/to/keywordsFile
+      Path to a file that contains strings to search.
+
+  -d, --date DATE-RANGE-HERE
+      You may specify either a single date, or a range; Using a single date will set the present as the end of the range. 
+      Single date: "2020-11-20". Range: "2020-11-10:2020-11-20".
+
+  -o, --output /path/to/outputFile
+      Path to a file where the output will be written.
+`
+
 func main() {
-	keywordFile := flag.String("keywords", "", "A txt file that contains strings to search.")
-	dateParam := flag.String("date", "", "A single date or a range to search. Single: YYYY-MM-DD Range:YYYY-MM-DD:YYYY-MM-DD")
-	outFile := flag.String("o", "", "Output file")
+	
+	var keywordFile string
+	var dateParam string
+	var outFile string
+
+	flag.StringVar(&keywordFile, "k", "", "A txt file that contains strings to search.")
+	flag.StringVar(&keywordFile, "keywords", "", "A txt file that contains strings to search.")
+	flag.StringVar(&dateParam, "d", "", "A single date or a range to search. Single: YYYY-MM-DD Range:YYYY-MM-DD:YYYY-MM-DD")
+	flag.StringVar(&dateParam, "date", "", "A single date or a range to search. Single: YYYY-MM-DD Range:YYYY-MM-DD:YYYY-MM-DD")
+	flag.StringVar(&outFile, "o", "", "Output file")
+	flag.StringVar(&outFile, "output", "", "Output file")
+	
+	//https://www.antoniojgutierrez.com/posts/2021-05-14-short-and-long-options-in-go-flags-pkg/
+	flag.Usage = func() { fmt.Print(usage) }
 	flag.Parse()
+
+
 	if *keywordFile == "" || *dateParam == "" || *outFile == "" {
 		color.Red("Please specify all arguments!")
 		flag.PrintDefaults()


### PR DESCRIPTION
It's commonplace for CLI programs to accept short and long forms of their arguments. urlhunter did not do this, so I updated it to be easier/faster to use.
Now we can use:

- -k, --keyword
- -d, --date
- -o, --output

I also corrected the documentation to match this update, and added `archive/` to the `.gitignore`.
I've standardized the output messages as well: Previously, they were scattered all over the place. I've now centralized them using crash(), warning() and info(). Each function has its own color. As a side effect, I've also made the color coding make more sense: only errors should be red, yet this program used the color red for non-critical events very often. I've corrected that.

I have also added the -a, --archive option so we can specify a path to the archives. I didn't document this option in the README though