### PR TITLE
Output Shortlinks and refactor searching code

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ You can download the pre-built binaries from the [releases](https://github.com/u
 
 urlhunter requires 3 parameters to run: `-keywords`, `-date` and `-o`. 
 
-For example: `urlhunter -keywords keywords.txt -date 2020-11-20 -o out.txt`
+For example: `urlhunter --keywords keywords.txt --date 2020-11-20 --o out.txt`
 
 ### --keywords
 

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,6 @@ go 1.15
 
 require (
 	github.com/fatih/color v1.10.0
-	github.com/rzhade3/beaconspec v0.0.0-20220908152424-9ee117a49aef
+	github.com/rzhade3/beaconspec v0.0.0-20220908173914-b45182d7ddf3
 	github.com/schollz/progressbar/v3 v3.7.1
 )

--- a/go.mod
+++ b/go.mod
@@ -4,5 +4,6 @@ go 1.15
 
 require (
 	github.com/fatih/color v1.10.0
+	github.com/rzhade3/beaconspec v0.0.0-20220908152424-9ee117a49aef
 	github.com/schollz/progressbar/v3 v3.7.1
 )

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,5 @@
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fatih/color v1.10.0 h1:s36xzo75JdqLaaWoiEHk767eHiwo0598uUxyfiPkDsg=
 github.com/fatih/color v1.10.0/go.mod h1:ELkj/draVOlAH/xkhN6mQ50Qd0MPOk5AAr3maGEBuJM=
@@ -11,11 +12,14 @@ github.com/mattn/go-runewidth v0.0.9 h1:Lm995f3rfxdpd6TSmuVCHVb/QhupuXlYr8sCI/Qd
 github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db h1:62I3jR2EmQ4l5rM/4FEfDWcRD+abF5XlKShorW5LRoQ=
 github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db/go.mod h1:l0dey0ia/Uv7NcFFVbCLtqEBQbrT4OCwCSKTEv6enCw=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/schollz/progressbar v1.0.0 h1:gbyFReLHDkZo8mxy/dLWMr+Mpb1MokGJ1FqCiqacjZM=
+github.com/rzhade3/beaconspec v0.0.0-20220908152424-9ee117a49aef h1:pUdPMuB/3D1DhN+z+aKJH2HFe65tO14vYUkshaSL29g=
+github.com/rzhade3/beaconspec v0.0.0-20220908152424-9ee117a49aef/go.mod h1:iTcJ+0KrnJXKBZvYH/Q6GKLhFuiXzD3z2PRae7xWqpY=
 github.com/schollz/progressbar/v3 v3.7.1 h1:aQR/t6d+1nURSdoMn6c7n0vJi5xQ3KndpF0n7R5wrik=
 github.com/schollz/progressbar/v3 v3.7.1/go.mod h1:CG/f0JmacksUc6TkZToO7tVq4t03zIQSQUtTd7F9GR4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20201112155050-0c6587e931a9 h1:umElSU9WZirRdgu2yFHY0ayQkEnKiOC1TtM3fWXFnoU=

--- a/go.sum
+++ b/go.sum
@@ -14,8 +14,8 @@ github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db h1:62I3jR2Em
 github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db/go.mod h1:l0dey0ia/Uv7NcFFVbCLtqEBQbrT4OCwCSKTEv6enCw=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/rzhade3/beaconspec v0.0.0-20220908152424-9ee117a49aef h1:pUdPMuB/3D1DhN+z+aKJH2HFe65tO14vYUkshaSL29g=
-github.com/rzhade3/beaconspec v0.0.0-20220908152424-9ee117a49aef/go.mod h1:iTcJ+0KrnJXKBZvYH/Q6GKLhFuiXzD3z2PRae7xWqpY=
+github.com/rzhade3/beaconspec v0.0.0-20220908173914-b45182d7ddf3 h1:2YkbhM98YoshI0K0BD95IoCFx+KNN1L/G0P5WzY2kac=
+github.com/rzhade3/beaconspec v0.0.0-20220908173914-b45182d7ddf3/go.mod h1:iTcJ+0KrnJXKBZvYH/Q6GKLhFuiXzD3z2PRae7xWqpY=
 github.com/schollz/progressbar/v3 v3.7.1 h1:aQR/t6d+1nURSdoMn6c7n0vJi5xQ3KndpF0n7R5wrik=
 github.com/schollz/progressbar/v3 v3.7.1/go.mod h1:CG/f0JmacksUc6TkZToO7tVq4t03zIQSQUtTd7F9GR4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/main.go
+++ b/main.go
@@ -234,7 +234,7 @@ func searchFile(fileLocation string, keyword string, outfile string) {
 	for scanner.Scan() {
 		if matcher(scanner.Bytes()) {
 
-			line, err := beaconspec.ParseLine(scanner.Text(), &metadata)
+			line, err := beaconspec.ParseLine(scanner.Text(), metadata)
 			if err != nil {
 				panic(err)
 			}

--- a/main.go
+++ b/main.go
@@ -63,7 +63,6 @@ var err error
 var archivesPath string
 
 func main() {
-
 	var keywordFile string
 	var dateParam string
 	var outFile string
@@ -227,7 +226,6 @@ func getArchive(body []byte, date string, keywordFile string, outfile string) {
 }
 
 func searchFile(fileLocation string, keyword string, outfile string) {
-
 	var path string
 
 	if strings.HasPrefix(fileLocation, "archives") {
@@ -382,20 +380,6 @@ func downloadFile(url string) {
 	)
 	io.Copy(io.MultiWriter(f, bar), resp.Body)
 	color.Green("Download Finished!")
-}
-
-func ByteCountSI(b int64) string {
-	const unit = 1000
-	if b < unit {
-		return fmt.Sprintf("%d B", b)
-	}
-	div, exp := int64(unit), 0
-	for n := b / unit; n >= unit; n /= unit {
-		div *= unit
-		exp++
-	}
-	return fmt.Sprintf("%.1f %cB",
-		float64(b)/float64(div), "kMGTPE"[exp])
 }
 
 func Unzip(src string, dest string) ([]string, error) {


### PR DESCRIPTION
This PR updates the searching logic to:

1. Refactors it to make it a little simpler, reducing the branching conditions
2. Use a Beaconfile parsing library to more robustly parse the dumpfiles
3. Output the shortlink that mapped to a given long link. 

The new output file from this PR will now be a CSV that looks like this:

```
shortlink,longlink
```

Closes https://github.com/utkusen/urlhunter/issues/14